### PR TITLE
Add single entrypoiny shortcut for script and css methods (cake4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ In your php-template or in layout you can import javascript files with:
 <?php $this->ViteScripts->script($options) ?>
 ```
 
+or using this shourtcut for a single entrypoint:
+
+```php
+<?php $this->ViteScripts->script('webroot_src/main.ts') ?>
+```
+
 If you imported CSS files inside your JavaScript files, this method automatically
 appends your css tags to the css view block.
 
@@ -63,6 +69,12 @@ In your php-template you can import css files with:
 
 ```php
 <?php $this->ViteScripts->css($options) ?>
+```
+
+or using this shourtcut for a single entrypoint:
+
+```php
+<?php $this->ViteScripts->script('webroot_src/style.css') ?>
 ```
 
 ## Configuration

--- a/src/View/Helper/ViteScriptsHelper.php
+++ b/src/View/Helper/ViteScriptsHelper.php
@@ -68,15 +68,18 @@ class ViteScriptsHelper extends Helper
      * * devEntries (string[]): entry files in development mode
      * * other options are rendered as attributes to the html tag
      *
-     * @param array $options see above
+     * @param string|array $options file entrypoint or script options
      * @param \ViteHelper\Utilities\ViteHelperConfig|null $config config instance
      * @return void
      * @throws \ViteHelper\Exception\ConfigurationException
      * @throws \ViteHelper\Exception\ManifestNotFoundException|\ViteHelper\Exception\InvalidArgumentException
      */
-    public function script(array $options = [], ?ViteHelperConfig $config = null): void
+    public function script(string|array $options = [], ?ViteHelperConfig $config = null): void
     {
         $config = $config ?: ViteHelperConfig::create();
+        if (is_string($options)) {
+            $options = ['files' => [$options]];
+        }
         $options['block'] = $options['block'] ?? $config->read('viewBlocks.script', ConfigDefaults::VIEW_BLOCK_SCRIPT);
         $options['cssBlock'] = $options['cssBlock'] ?? $config->read('viewBlocks.css', ConfigDefaults::VIEW_BLOCK_CSS);
         $options = $this->updateOptionsForFiltersAndEntries($options);
@@ -181,17 +184,19 @@ class ViteScriptsHelper extends Helper
      * * devEntries (string[]): entry files in development mode
      * * other options are rendered as attributes to the html tag
      *
-     * @param array $options see above
+     * @param string|array $options file entrypoint or css options
      * @param \ViteHelper\Utilities\ViteHelperConfig|null $config config instance
      * @return void
      * @throws \ViteHelper\Exception\ManifestNotFoundException
      * @throws \ViteHelper\Exception\ConfigurationException
      * @throws \ViteHelper\Exception\InvalidArgumentException
      */
-    public function css(array $options = [], ?ViteHelperConfig $config = null): void
+    public function css(string|array $options = [], ?ViteHelperConfig $config = null): void
     {
         $config = $config ?: ViteHelperConfig::create();
-
+        if (is_string($options)) {
+            $options = ['files' => [$options]];
+        }
         $options['block'] = $options['block'] ?? $config->read('viewBlocks.css', ConfigDefaults::VIEW_BLOCK_SCRIPT);
         $options = $this->updateOptionsForFiltersAndEntries($options);
 


### PR DESCRIPTION
Added support for single entrypoint loading for `script` and `css` methods, as described in the #12 issue.
I'll open the same PR for cake5 once this has been approved.