### PR TITLE
Check unreadable manifest to enable dev mode [CakePHP 4]

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ your own instance of `ViteHelperConfig` to a helper method as a second parameter
         'styleEntries' =>  ['someFolder/myStyleEntry.scss'], // relative to project root. Unnecessary when using css-in-js.
         'hostNeedles' => ['.test', '.local'], // to check if the app is running locally
         'url' => 'http://localhost:3000', // url of the vite dev server
+        'checkManifest' => false, // check if the manifest file does not exist and enable dev mode
     ],
     'forceProductionMode' => false, // or true to always serve build assets
     'plugin' => false, // or string 'MyPlugin' to serve plugin build assets

--- a/config/app_vite.php
+++ b/config/app_vite.php
@@ -12,6 +12,7 @@ return [
 			'scriptEntries' => ConfigDefaults::DEVELOPMENT_SCRIPT_ENTRIES,
 			'styleEntries' => ConfigDefaults::DEVELOPMENT_STYLE_ENTRIES,
 			'hostNeedles' => ConfigDefaults::DEVELOPMENT_HOST_NEEDLES,
+			'checkManifest' => ConfigDefaults::DEVELOPMENT_CHECK_MANIFEST,
 			'url' => ConfigDefaults::DEVELOPMENT_URL,
 		],
 		'forceProductionMode' => ConfigDefaults::FORCE_PRODUCTION_MODE,

--- a/src/Utilities/ConfigDefaults.php
+++ b/src/Utilities/ConfigDefaults.php
@@ -26,6 +26,11 @@ class ConfigDefaults
     ];
 
     /**
+     * If true, the manifest file will be checked for existence and readability in order to detect development mode
+     */
+    public const DEVELOPMENT_CHECK_MANIFEST = false;
+
+    /**
      * for Cookies or URL-params to force production mode
      */
     public const PRODUCTION_HINT = 'vprod';

--- a/src/View/Helper/ViteScriptsHelper.php
+++ b/src/View/Helper/ViteScriptsHelper.php
@@ -8,6 +8,7 @@ use Cake\Utility\Text;
 use Cake\View\Helper;
 use ViteHelper\Exception\ConfigurationException;
 use ViteHelper\Exception\InvalidArgumentException;
+use ViteHelper\Exception\ManifestNotFoundException;
 use ViteHelper\Utilities\ConfigDefaults;
 use ViteHelper\Utilities\ManifestRecord;
 use ViteHelper\Utilities\ManifestRecords;
@@ -51,6 +52,14 @@ class ViteScriptsHelper extends Helper
         $needles = $config->read('development.hostNeedles', ConfigDefaults::DEVELOPMENT_HOST_NEEDLES);
         foreach ($needles as $needle) {
             if (str_contains((string)$this->getView()->getRequest()->host(), $needle)) {
+                return true;
+            }
+        }
+
+        if ($config->read('development.checkManifest', ConfigDefaults::DEVELOPMENT_CHECK_MANIFEST)) {
+            try {
+                ViteManifest::getRecords($config);
+            } catch (ManifestNotFoundException $e) {
                 return true;
             }
         }


### PR DESCRIPTION
This PR introduces a new `development.checkManifest` param. When `true` (defaults to `false` for backward compatibility) the helper will look for manifest readability in order to detect dev mode.

This is a proposal PR, I'll create the cake 5 version once this has been approved.