### PR TITLE
Remove files to be rendered as an attr in script tag

### DIFF
--- a/src/View/Helper/ViteScriptsHelper.php
+++ b/src/View/Helper/ViteScriptsHelper.php
@@ -138,6 +138,7 @@ class ViteScriptsHelper extends Helper
         unset($options['cssBlock']);
         unset($options['prodFilter']);
         unset($options['devEntries']);
+        unset($options['files']);
         $options['type'] = 'module';
 
         foreach ($files as $file) {
@@ -165,6 +166,7 @@ class ViteScriptsHelper extends Helper
         unset($options['prodFilter']);
         unset($options['cssBlock']);
         unset($options['devEntries']);
+        unset($options['files']);
 
         foreach ($records as $record) {
             if (!$record->isEntryScript()) {


### PR DESCRIPTION
Currently, when rendering the script tag it adds the "files" parameter as an attribute, which is not necessary.

For example: <script src="path/to/file.js" files="path/to/file.js" ... >